### PR TITLE
Suggested Bugfix 

### DIFF
--- a/flatland/entities/__init__.py
+++ b/flatland/entities/__init__.py
@@ -1,4 +1,5 @@
 from .entity import *
+from flatland.entities.collection.basic import *
 from flatland.entities.collection.contact import *
 from flatland.entities.collection.zone import *
 from flatland.entities.collection.interactive import *

--- a/flatland/entities/entity.py
+++ b/flatland/entities/entity.py
@@ -50,6 +50,8 @@ class Entity:
             mass (:obj: 'float'): mass of the entity
         """
 
+
+
         self.graspable = entity_params.get('graspable', self.graspable)
         self.movable = entity_params.get('movable', self.movable)
 
@@ -66,6 +68,9 @@ class Entity:
 
         self.visible_vertices = self.compute_vertices(self.radius)
         self.interaction_vertices = self.compute_vertices(self.interaction_radius)
+
+        # To be set when entity is added to playground. Used to calculate correct coordinates
+        self.size_playground = [0,0]
 
         self.pm_body = self.create_pm_body()
         self.velocity = [0, 0, 0]
@@ -88,14 +93,15 @@ class Entity:
             self.interaction_mask = self.create_interaction_mask()
             self.pm_elements.append(self.pm_interaction_shape)
 
+
+
         self.initial_position = initial_position
 
         # Internal counter to assign identity number and name to each entity
         self.name = self.entity_type+'_' + str(Entity.index_entity)
         Entity.index_entity += 1
 
-        # To be set when entity is added to playground. Used to calculate correct coordinates
-        self.size_playground = None
+
 
         # To remove temporary entities when reset
         self.is_temporary_entity = entity_params.get('is_temporary_entity', False)
@@ -206,6 +212,7 @@ class Entity:
 
     @position.setter
     def position(self, position):
+
 
         coord_x, coord_y, coord_phi = position
 

--- a/flatland/tests/test_basics/test.py
+++ b/flatland/tests/test_basics/test.py
@@ -2,16 +2,27 @@ from flatland.tests.test_basics.entities_pg import *
 from flatland.tests.test_basics.advanced_pg import *
 from flatland.agents import agent
 
-# pg = Basic_01()
+#pg = Basic_01()
 # pg = Contact_01()
-pg = Interactive_01()
-# pg = Doors_01()
+#pg = Interactive_01()
+pg = Doors_01()
 # pg = Zones_01()
 # pg = Proximity_01()
 # pg = Trajectory_01()
 #pg = Fields_01()
 
-# pg = Rooms_Doors()
+# pg = Rooms+
+
+
+
+
+
+
+
+
+
+
+#_Doors()
 
 
 # for entity in pg.entities:


### PR DESCRIPTION
- size_playground must be a number set before any change to entity 
position, because the property setter use it
I suggest it to default it to `[0,0]` instead of `None`. This value corresponds to an empty room and has the right shape (a 2-value array of numbers)

- test playgrounds need the `Basic` class to be imported
I suggest to import it too in the entity package `__init__` file